### PR TITLE
Use latest gem paypalhttp for Ruby3

### DIFF
--- a/paypal-checkout-sdk.gemspec
+++ b/paypal-checkout-sdk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'paypalhttp', '~> 1.0.1'
+  spec.add_dependency 'paypalhttp'
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Solve deprecated method `URI.escape`.

<img width="1394" alt="image" src="https://user-images.githubusercontent.com/1373402/185269252-6af8d25f-2dd2-4372-808f-b2157230344f.png">
